### PR TITLE
fix: build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ ADD requirements.txt /requirements.txt
 ADD entrypoint.sh /entrypoint.sh
 ADD github.py /github.py
 
-RUN apk add gcc musl-dev && \
+RUN pip install --upgrade pip setuptools wheel && \
+    apk add gcc musl-dev && \
     pip install -r requirements.txt
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Description
This PR fixes the build error related to `pylint-celery` package installation in the Docker image. The error was occurring because the `wheel` package was not installed in the environment, which is required for building Python packages.

## Changes Made
- Added `pip install --upgrade pip setuptools wheel` to the Dockerfile's RUN command
- This ensures that the necessary build tools are available before installing the requirements
- The change maintains the existing `gcc` and `musl-dev` dependencies while adding the required Python build tools

## Error Fixed
The following error was occurring during the build process:
![image](https://github.com/user-attachments/assets/8f692eda-3f5a-4b08-b33e-382ccac39684)

## Testing
The changes have been tested locally and the Docker build now completes successfully without the wheel building error for `pylint-celery` and other packages that require wheel building.